### PR TITLE
use Debian 8 (highest version not requiring changes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:7.7
+FROM debian:8
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN dpkg --add-architecture i386


### PR DESCRIPTION
Je n'ai pas pu push sur `softinnov/cheyenne:8` (pas les permissions requises).